### PR TITLE
feat: add ast-grep MCP integration for code analysis

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -7,6 +7,9 @@ tools:
   - Glob
   - Grep
   - Bash
+  - mcp__ast-grep__find_code
+  - mcp__ast-grep__search_by_rule
+  - mcp__ast-grep__get_all_rules
 ---
 
 # Code Reviewer - Code Review Expert
@@ -115,6 +118,40 @@ Required checks during review:
 **TypeScript/React:**
 - [ ] No any types
 - [ ] Error/loading/empty states handled
+
+## ast-grep Pattern Matching
+
+Use ast-grep for structural code analysis. More accurate than text-based grep.
+
+### Available Tools
+- `find_code`: Search by AST pattern (e.g., `console.log($ARG)`)
+- `search_by_rule`: Search using predefined YAML rules
+- `get_all_rules`: List available rules
+
+### Security Rules
+| Rule ID | Description |
+|---------|-------------|
+| `security/xss-innerhtml` | innerHTML XSS vulnerability |
+| `security/sql-injection` | SQL string concatenation |
+| `security/no-eval` | eval() and Function() usage |
+| `security/hardcoded-secrets` | Hardcoded API keys/passwords |
+| `security/command-injection` | Dangerous exec/spawn patterns |
+
+### Quality Rules
+| Rule ID | Description |
+|---------|-------------|
+| `quality/no-console-log` | console.log in production |
+| `quality/no-any-type` | TypeScript `any` usage |
+| `quality/unhandled-promise` | Promises without catch |
+
+### Usage Examples
+```
+# Find all eval() calls
+find_code(pattern="eval($CODE)", lang="javascript")
+
+# Use predefined security rule
+search_by_rule(rule_id="security/xss-innerhtml")
+```
 
 ## Principles
 

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -9,6 +9,9 @@ tools:
   - Bash
   - LSP
   - Edit
+  - mcp__ast-grep__find_code
+  - mcp__ast-grep__search_by_rule
+  - mcp__ast-grep__get_all_rules
 ---
 
 # Debugger - Debugging Expert
@@ -135,6 +138,36 @@ Patterns to watch during debugging:
 - [ ] Timeout configured
 - [ ] Resource cleanup guaranteed
 - [ ] No blocking calls (async context)
+
+## ast-grep for Bug Hunting
+
+Use ast-grep for structural pattern search when debugging.
+
+### Available Tools
+- `find_code`: Search by AST pattern
+- `search_by_rule`: Search using predefined rules
+- `get_all_rules`: List available rules
+
+### Debug Patterns
+```
+# Find all try-catch blocks
+find_code(pattern="try { $$$ } catch($E) { $$$ }", lang="javascript")
+
+# Find async functions without await
+find_code(pattern="async function $NAME($$$) { $BODY }", lang="javascript")
+
+# Find all event listeners (potential memory leaks)
+find_code(pattern="addEventListener($EVENT, $HANDLER)", lang="javascript")
+
+# Find potential null references
+find_code(pattern="$X.then($$$)", lang="javascript")
+```
+
+### Bug-Related Rules
+| Rule ID | Description |
+|---------|-------------|
+| `quality/unhandled-promise` | Missing .catch() or try-catch |
+| `quality/no-console-log` | Debug logs left in code |
 
 ## Principles
 

--- a/.claude/ast-grep/README.md
+++ b/.claude/ast-grep/README.md
@@ -1,0 +1,73 @@
+# ast-grep Rules Library
+
+Pre-defined rules for security and code quality analysis.
+
+## Directory Structure
+
+```
+ast-grep/
+├── sgconfig.yaml       # Main configuration
+└── rules/
+    ├── security/       # Security vulnerability rules
+    └── quality/        # Code quality rules
+```
+
+## Security Rules
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| `security/xss-innerhtml` | error | Detect innerHTML with dynamic content |
+| `security/sql-injection` | error | Detect SQL string concatenation |
+| `security/no-eval` | error | Detect eval() and Function() |
+| `security/hardcoded-secrets` | error | Detect hardcoded API keys/passwords |
+| `security/command-injection` | error | Detect dangerous shell execution |
+
+## Quality Rules
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| `quality/no-console-log` | warning | Detect console.log statements |
+| `quality/no-any-type` | warning | Detect TypeScript `any` usage |
+| `quality/unhandled-promise` | warning | Detect promises without .catch() |
+
+## Usage
+
+### Via Agent Tools
+```
+# Using code-reviewer or debugger agents
+search_by_rule(rule_id="security/xss-innerhtml")
+```
+
+### Via CLI
+```bash
+# Run all rules
+ast-grep scan --config ~/.claude/ast-grep/sgconfig.yaml
+
+# Run specific rule
+ast-grep scan --rule security/xss-innerhtml.yaml
+```
+
+## Adding Custom Rules
+
+1. Create a YAML file in the appropriate `rules/` subdirectory
+2. Follow the ast-grep rule format:
+
+```yaml
+id: category/rule-name
+language: javascript
+severity: error|warning|hint
+message: "Short description of the issue"
+note: "Explanation and suggested fix"
+rule:
+  pattern: your_pattern_here
+```
+
+3. Test your rule:
+```bash
+ast-grep test --config sgconfig.yaml
+```
+
+## References
+
+- [ast-grep Rule Guide](https://ast-grep.github.io/guide/rule-config.html)
+- [ast-grep Pattern Syntax](https://ast-grep.github.io/guide/pattern-syntax.html)

--- a/.claude/ast-grep/rules/quality/no-any-type.yaml
+++ b/.claude/ast-grep/rules/quality/no-any-type.yaml
@@ -1,0 +1,9 @@
+id: quality/no-any-type
+language: typescript
+severity: warning
+message: "Avoid using 'any' type"
+note: "Use specific types or 'unknown' if type is truly unknown"
+rule:
+  any:
+    - pattern: ": any"
+    - pattern: "as any"

--- a/.claude/ast-grep/rules/quality/no-console-log.yaml
+++ b/.claude/ast-grep/rules/quality/no-console-log.yaml
@@ -1,0 +1,10 @@
+id: quality/no-console-log
+language: javascript
+severity: warning
+message: "Remove console.log before production"
+note: "Use proper logging library instead"
+rule:
+  any:
+    - pattern: console.log($$$)
+    - pattern: console.debug($$$)
+    - pattern: console.info($$$)

--- a/.claude/ast-grep/rules/quality/unhandled-promise.yaml
+++ b/.claude/ast-grep/rules/quality/unhandled-promise.yaml
@@ -1,0 +1,7 @@
+id: quality/unhandled-promise
+language: javascript
+severity: warning
+message: "Unhandled promise - missing error handling"
+note: "Add .catch() or use try-catch with async/await"
+rule:
+  pattern: $PROMISE.then($HANDLER)

--- a/.claude/ast-grep/rules/security/command-injection.yaml
+++ b/.claude/ast-grep/rules/security/command-injection.yaml
@@ -1,0 +1,12 @@
+id: security/command-injection
+language: javascript
+severity: error
+message: "Potential command injection vulnerability"
+note: "Validate and sanitize user input before shell execution"
+rule:
+  any:
+    - pattern: exec($CMD + $VAR)
+    - pattern: exec(`$$$`)
+    - pattern: execSync($CMD + $VAR)
+    - pattern: execSync(`$$$`)
+    - pattern: spawn($CMD, [$$$])

--- a/.claude/ast-grep/rules/security/hardcoded-secrets.yaml
+++ b/.claude/ast-grep/rules/security/hardcoded-secrets.yaml
@@ -1,0 +1,15 @@
+id: security/hardcoded-secrets
+language: javascript
+severity: error
+message: "Potential hardcoded secret detected"
+note: "Move secrets to environment variables"
+rule:
+  any:
+    - pattern: apiKey = "$$$"
+    - pattern: apiKey: "$$$"
+    - pattern: password = "$$$"
+    - pattern: password: "$$$"
+    - pattern: secret = "$$$"
+    - pattern: secret: "$$$"
+    - pattern: token = "$$$"
+    - pattern: token: "$$$"

--- a/.claude/ast-grep/rules/security/no-eval.yaml
+++ b/.claude/ast-grep/rules/security/no-eval.yaml
@@ -1,0 +1,9 @@
+id: security/no-eval
+language: javascript
+severity: error
+message: "Dangerous: eval() or Function() can execute arbitrary code"
+note: "Avoid eval() and new Function() - find safer alternatives"
+rule:
+  any:
+    - pattern: eval($CODE)
+    - pattern: new Function($$$)

--- a/.claude/ast-grep/rules/security/sql-injection.yaml
+++ b/.claude/ast-grep/rules/security/sql-injection.yaml
@@ -1,0 +1,10 @@
+id: security/sql-injection
+language: javascript
+severity: error
+message: "Potential SQL injection: string concatenation in query"
+note: "Use parameterized queries instead"
+rule:
+  any:
+    - pattern: $DB.query($STR + $VAR)
+    - pattern: $DB.query(`$$$`)
+    - pattern: $DB.execute($STR + $VAR)

--- a/.claude/ast-grep/rules/security/xss-innerhtml.yaml
+++ b/.claude/ast-grep/rules/security/xss-innerhtml.yaml
@@ -1,0 +1,10 @@
+id: security/xss-innerhtml
+language: javascript
+severity: error
+message: "Potential XSS vulnerability: innerHTML with dynamic content"
+note: "Use textContent or sanitize input before using innerHTML"
+rule:
+  any:
+    - pattern: $EL.innerHTML = $VAR
+    - pattern: $EL.innerHTML += $VAR
+    - pattern: document.write($VAR)

--- a/.claude/ast-grep/sgconfig.yaml
+++ b/.claude/ast-grep/sgconfig.yaml
@@ -1,0 +1,9 @@
+ruleDirs:
+  - rules
+
+languageGlobs:
+  javascript: ["*.js", "*.jsx", "*.mjs", "*.cjs"]
+  typescript: ["*.ts", "*.tsx", "*.mts", "*.cts"]
+  python: ["*.py"]
+  go: ["*.go"]
+  rust: ["*.rs"]

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,6 +13,7 @@
       "Bash(winget:*)",
       "Bash(rm:*)",
       "Bash(ls:*)",
+      "Bash(ast-grep:*)",
       "WebSearch",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
@@ -21,7 +22,8 @@
       "Read(**)",
       "Glob(**)",
       "Grep(**)",
-      "Bash(bash:*)"
+      "Bash(bash:*)",
+      "mcp__ast-grep__*"
     ]
   },
   "hooks": {
@@ -145,6 +147,14 @@
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
+    },
+    "ast-grep": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/ast-grep/ast-grep-mcp",
+        "ast-grep-mcp"
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ The install script will:
 
 See [agents.md](./agents.md) for details.
 
-## MCP Servers (3)
+## MCP Servers (4)
 
 | MCP | Purpose | Authentication |
 |-----|---------|----------------|
 | **Context7** | Latest library documentation lookup | Not required |
 | **Figma** | Figma design data retrieval | `FIGMA_API_KEY` required |
 | **GitHub** | Repository, issue, PR access | `gh auth login` or PAT |
+| **ast-grep** | AST-based structural code search | Not required |
 
 ### GitHub MCP Setup (Recommended: OAuth)
 ```bash
@@ -81,6 +82,25 @@ export GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token)
 ```bash
 export FIGMA_API_KEY="your-figma-api-key"
 ```
+
+### ast-grep MCP Setup
+```bash
+# Install ast-grep CLI
+brew install ast-grep  # macOS
+cargo install ast-grep # or via Rust
+
+# Install uv (for MCP server)
+brew install uv  # macOS
+pip install uv   # or via pip
+```
+
+**Features:**
+- AST-based code pattern matching (more accurate than text search)
+- Pre-defined security rules (XSS, SQL injection, eval, secrets)
+- Pre-defined quality rules (console.log, any type, unhandled promises)
+- Used by `code-reviewer` and `debugger` agents
+
+See [.claude/ast-grep/README.md](./.claude/ast-grep/README.md) for rules documentation.
 
 ## Hooks (13)
 
@@ -164,17 +184,22 @@ claude_agents/
 ├── .claude/
 │   ├── settings.local.json   # Claude Code settings (MCP, hooks)
 │   ├── CLAUDE.md             # Agent orchestration rules
-│   └── agents/               # Subagent definitions (10)
-│       ├── oracle.md
-│       ├── planner.md
-│       ├── explore.md
-│       ├── code-reviewer.md
-│       ├── frontend-designer.md
-│       ├── librarian.md
-│       ├── debugger.md
-│       ├── test-writer.md
-│       ├── refactorer.md
-│       └── formatter.md
+│   ├── agents/               # Subagent definitions (10)
+│   │   ├── oracle.md
+│   │   ├── planner.md
+│   │   ├── explore.md
+│   │   ├── code-reviewer.md
+│   │   ├── frontend-designer.md
+│   │   ├── librarian.md
+│   │   ├── debugger.md
+│   │   ├── test-writer.md
+│   │   ├── refactorer.md
+│   │   └── formatter.md
+│   └── ast-grep/             # AST-based code analysis rules
+│       ├── sgconfig.yaml
+│       └── rules/
+│           ├── security/     # XSS, SQL injection, eval, etc.
+│           └── quality/      # console.log, any type, etc.
 ├── hooks/                    # Event-based hooks
 ├── skills/                   # Slash commands
 ├── mcp/
@@ -211,3 +236,5 @@ cp -r skills/* ~/.claude/skills/
 - [Context7 MCP](https://github.com/upstash/context7)
 - [Figma MCP](https://github.com/GLips/Figma-Context-MCP)
 - [GitHub MCP](https://github.com/modelcontextprotocol/servers)
+- [ast-grep](https://ast-grep.github.io/)
+- [ast-grep MCP](https://github.com/ast-grep/ast-grep-mcp)

--- a/install.ps1
+++ b/install.ps1
@@ -83,6 +83,16 @@ if (Test-Path $MCP_SOURCE) {
     Write-Host "MCP config copied to: $CLAUDE_DIR\mcp.json" -ForegroundColor Green
 }
 
+# ast-grep 규칙 복사
+$AST_GREP_DIR = "$CLAUDE_DIR\ast-grep"
+if (!(Test-Path $AST_GREP_DIR)) {
+    New-Item -ItemType Directory -Path $AST_GREP_DIR -Force | Out-Null
+}
+if (Test-Path "$SCRIPT_DIR\.claude\ast-grep") {
+    Copy-Item "$SCRIPT_DIR\.claude\ast-grep\*" $AST_GREP_DIR -Recurse -Force
+    Write-Host "ast-grep rules copied to: $AST_GREP_DIR" -ForegroundColor Green
+}
+
 Write-Host ""
 Write-Host "설치 완료!" -ForegroundColor Green
 Write-Host ""
@@ -105,4 +115,12 @@ Write-Host "  # 방법 2: PAT 직접 설정"
 Write-Host "  set GITHUB_PERSONAL_ACCESS_TOKEN=your-token"
 Write-Host ""
 Write-Host "  claude mcp add github -- npx -y @modelcontextprotocol/server-github"
+Write-Host ""
+Write-Host "ast-grep MCP 서버 사용 (선택):" -ForegroundColor Yellow
+Write-Host "  # ast-grep CLI 설치"
+Write-Host "  winget install ast-grep.ast-grep  # Windows"
+Write-Host "  cargo install ast-grep            # 또는 Rust"
+Write-Host ""
+Write-Host "  # uv 설치 (ast-grep MCP 서버용)"
+Write-Host "  pip install uv"
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,14 @@ if [ -f "$MCP_SOURCE" ]; then
     echo -e "\033[32mMCP config copied to: $CLAUDE_DIR/mcp.json\033[0m"
 fi
 
+# ast-grep 규칙 복사
+AST_GREP_DIR="$CLAUDE_DIR/ast-grep"
+mkdir -p "$AST_GREP_DIR"
+if [ -d "$SCRIPT_DIR/.claude/ast-grep" ]; then
+    cp -r "$SCRIPT_DIR/.claude/ast-grep/"* "$AST_GREP_DIR/"
+    echo -e "\033[32mast-grep rules copied to: $AST_GREP_DIR\033[0m"
+fi
+
 echo ""
 echo -e "\033[32m설치 완료!\033[0m"
 echo ""
@@ -100,4 +108,13 @@ echo "  # 방법 2: PAT 직접 설정"
 echo "  export GITHUB_PERSONAL_ACCESS_TOKEN=your-token"
 echo ""
 echo "  claude mcp add github -- npx -y @modelcontextprotocol/server-github"
+echo ""
+echo -e "\033[33mast-grep MCP 서버 사용 (선택):\033[0m"
+echo "  # ast-grep CLI 설치"
+echo "  brew install ast-grep  # macOS"
+echo "  cargo install ast-grep # 또는 Rust"
+echo ""
+echo "  # uv 설치 (ast-grep MCP 서버용)"
+echo "  brew install uv  # macOS"
+echo "  pip install uv   # 또는 pip"
 echo ""


### PR DESCRIPTION
## Summary
- Add ast-grep MCP server for AST-based structural code search
- Integrate ast-grep tools into code-reviewer and debugger agents
- Create pre-defined security and quality rules library

## Changes

### MCP Server
- Add ast-grep MCP server configuration in `settings.local.json`
- Add `mcp__ast-grep__*` permission

### Agent Updates
- `code-reviewer.md`: Add ast-grep tools and usage guide
- `debugger.md`: Add ast-grep tools and debug patterns

### Rules Library (`.claude/ast-grep/`)
**Security Rules:**
- `xss-innerhtml` - innerHTML XSS vulnerability
- `sql-injection` - SQL string concatenation
- `no-eval` - eval() and Function() usage
- `hardcoded-secrets` - Hardcoded API keys/passwords
- `command-injection` - Dangerous exec/spawn patterns

**Quality Rules:**
- `no-console-log` - console.log in production
- `no-any-type` - TypeScript `any` usage
- `unhandled-promise` - Promises without catch

### Install Scripts
- Update `install.sh` and `install.ps1` to copy ast-grep rules

## Prerequisites
```bash
# macOS
brew install ast-grep
brew install uv

# Or via cargo/pip
cargo install ast-grep
pip install uv
```

## Test plan
- [x] Verify MCP server starts
- [x] Test code-reviewer agent with ast-grep tools
- [x] Test debugger agent with ast-grep tools
- [x] Run install script and verify ast-grep rules copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)