### PR TITLE
fix: add uv support for Python test detection

### DIFF
--- a/hooks/pre-commit-test.js
+++ b/hooks/pre-commit-test.js
@@ -32,7 +32,9 @@ const TEST_CONFIGS = [
   { files: ['jest.config.js', 'jest.config.ts'], testCmd: 'npx jest' },
   { files: ['vitest.config.js', 'vitest.config.ts'], testCmd: 'npx vitest run' },
 
-  // Python
+  // Python (uv projects - check first)
+  { files: ['uv.lock'], testCmd: 'uv run pytest', testDirs: ['tests', 'test'] },
+  // Python (standard)
   { files: ['pytest.ini', 'pyproject.toml', 'setup.py'], testCmd: 'pytest', testDirs: ['tests', 'test'] },
   { files: ['tox.ini'], testCmd: 'tox' },
 


### PR DESCRIPTION
## Summary
- Pre-commit test hook now detects uv-managed Python projects
- Uses `uv run pytest` instead of bare `pytest` when `uv.lock` exists
- Maintains backward compatibility with standard Python projects

## Test plan
- [ ] Verify uv projects use `uv run pytest`
- [ ] Verify non-uv projects still use `pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)